### PR TITLE
⚡ Bolt: Add SQLite index on alerts timestamp

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-02-28 - Unmemoized Filtering and Sorting in React Render
 **Learning:** Found a critical performance bottleneck in `LiveTraffic.tsx` where filtering and sorting of a very large array (up to 10,000 packets) occurred on every render cycle. This resulted in significant CPU overhead and blocked the main thread.
 **Action:** Always wrap heavy data processing operations (like filtering and sorting large datasets) in `useMemo` hooks, specifying exactly which dependencies should trigger a re-evaluation to avoid running complex operations synchronously inside the component body on each update.
+## 2025-02-28 - Missing Index causes O(N) Table Scan in SQLite
+**Learning:** The `get_telemetry_stats` query uses a date range `WHERE timestamp >= ?1` which without an index results in a slow full table scan.
+**Action:** When querying rows over a time range, always ensure there is an index on the timestamp column.

--- a/core/apps/guard-shield-tauri/src-tauri/src/database.rs
+++ b/core/apps/guard-shield-tauri/src-tauri/src/database.rs
@@ -106,6 +106,10 @@ pub fn init_db(app_dir: PathBuf) -> Result<DatabaseState> {
     let _ = conn.execute("ALTER TABLE alerts ADD COLUMN src_country TEXT", []);
     let _ = conn.execute("ALTER TABLE alerts ADD COLUMN dst_country TEXT", []);
 
+    // ⚡ Bolt Optimization: Add index to speed up `get_telemetry_stats` range query on `timestamp`.
+    // Turns O(N) full table scan into an O(log N) index lookup.
+    let _ = conn.execute("CREATE INDEX IF NOT EXISTS idx_alerts_timestamp ON alerts (timestamp)", []);
+
     Ok(DatabaseState { conn: Mutex::new(conn) })
 }
 


### PR DESCRIPTION
💡 What: Add index `idx_alerts_timestamp` on the `timestamp` column of the `alerts` table.
🎯 Why: `get_telemetry_stats` runs a range query (`>=`) on `timestamp`. Without an index, SQLite performs a full table scan, degrading performance as the number of alerts grows.
📊 Impact: Turns O(N) full table scan into an O(log N) index lookup for checking alerts in the last 24 hours. Measurably faster dashboard loading and telemetry fetching over time.
🔬 Measurement: EXPLAIN QUERY PLAN shows a change from `SCAN alerts` to `SEARCH alerts USING COVERING INDEX idx_alerts_timestamp (timestamp>?)`.

---
*PR created automatically by Jules for task [8640316653040278039](https://jules.google.com/task/8640316653040278039) started by @lakshyarawat1*