### PR TITLE
🛡️ Sentinel: [HIGH] Fix WinDivert Filter String Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Application internally exposed raw Tauri error objects, including messages and serialized JSON, directly to the user via JavaScript `alert()` pop-ups when window creation failed.
 **Learning:** This practice can inadvertently leak sensitive internal paths, stack traces, or configuration details, violating the "fail securely" principle and providing potential reconnaissance data to an attacker.
 **Prevention:** Always log detailed error information to the developer console (`console.error`) and display generic, non-revealing failure messages to the user in the UI.
+
+## 2026-06-22 - WinDivert Filter String Injection
+**Vulnerability:** User inputs (IP addresses and ports) were dynamically concatenated directly into WinDivert packet filter strings without validation. An attacker could provide malicious input like `1.1.1.1 or true` to alter the logic of the filter engine.
+**Learning:** Filter string injection is a lesser-known but highly impactful vulnerability comparable to SQL injection, specifically affecting non-SQL query interfaces like BPF (Berkeley Packet Filter) or WinDivert filter strings. Unvalidated input can cause the system to drop all packets (DoS) or bypass intended IPS rules.
+**Prevention:** Always parse and explicitly validate network-related user input (e.g., verifying it successfully parses as `std::net::IpAddr` or `u16` ports) before incorporating it into packet filtering rules.

--- a/core/apps/guard-shield-tauri/src-tauri/src/lib.rs
+++ b/core/apps/guard-shield-tauri/src-tauri/src/lib.rs
@@ -117,6 +117,10 @@ fn block_ip(
     state: State<'_, AppState>,
     db_state: State<'_, database::DatabaseState>,
 ) -> Result<(), String> {
+    if ip.parse::<std::net::IpAddr>().is_err() {
+        return Err(format!("Invalid IP address format: {}", ip));
+    }
+
     {
         let w_ips = state.whitelisted_ips.read().unwrap();
         if w_ips.contains(&ip) {
@@ -180,6 +184,10 @@ fn whitelist_ip(
     state: State<'_, AppState>,
     db_state: State<'_, database::DatabaseState>,
 ) -> Result<(), String> {
+    if ip.parse::<std::net::IpAddr>().is_err() {
+        return Err(format!("Invalid IP address format: {}", ip));
+    }
+
     {
         let b_ips = state.blocked_ips.read().unwrap();
         if b_ips.contains(&ip) {
@@ -303,6 +311,27 @@ fn trigger_mock_alert(
 
 #[tauri::command]
 fn add_custom_rule(state: State<'_, AppState>, db_state: State<'_, database::DatabaseState>, rule: database::CustomRule) -> Result<i64, String> {
+    if let Some(src) = &rule.src_ip {
+        if !src.is_empty() && src.parse::<std::net::IpAddr>().is_err() {
+            return Err("Invalid source IP address".to_string());
+        }
+    }
+    if let Some(dst) = &rule.dst_ip {
+        if !dst.is_empty() && dst.parse::<std::net::IpAddr>().is_err() {
+            return Err("Invalid destination IP address".to_string());
+        }
+    }
+    if let Some(p) = &rule.src_port {
+        if !p.is_empty() && p.parse::<u16>().is_err() {
+            return Err("Invalid source port".to_string());
+        }
+    }
+    if let Some(p) = &rule.dst_port {
+        if !p.is_empty() && p.parse::<u16>().is_err() {
+            return Err("Invalid destination port".to_string());
+        }
+    }
+
     let conn = db_state.conn.lock().unwrap();
     let id = database::insert_custom_rule(&conn, &rule).map_err(|e| e.to_string())?;
     let _ = database::log_audit_event(&conn, "USER_ACTION", "INFO", "Added Custom Rule", &format!("Rule '{}' for protocol {}", rule.name, rule.protocol));


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: WinDivert Filter String Injection. The Tauri backend directly embedded user-provided IP addresses and ports into a WinDivert packet filter string without prior validation.
🎯 Impact: An attacker could bypass IPS drop/alert rules or cause a Denial of Service by injecting malicious filter strings (e.g. `1.1.1.1 or true`) into the underlying network engine.
🔧 Fix: Added strict type parsing validation (using `std::net::IpAddr::from_str` and `u16::from_str`) in all Tauri commands that accept IP or port input (`block_ip`, `whitelist_ip`, `add_custom_rule`) before passing them to the IPS engine.
✅ Verification: Ran `cargo check --target x86_64-pc-windows-gnu` and `pnpm lint` and `pnpm build`. Validated that invalid IP input correctly fails the parse and returns an error immediately to the client.

---
*PR created automatically by Jules for task [17309117566870135646](https://jules.google.com/task/17309117566870135646) started by @lakshyarawat1*