### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix WinDivert filter string injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** User inputs (IP addresses and ports) were dynamically concatenated directly into WinDivert packet filter strings without validation. An attacker could provide malicious input like `1.1.1.1 or true` to alter the logic of the filter engine.
 **Learning:** Filter string injection is a lesser-known but highly impactful vulnerability comparable to SQL injection, specifically affecting non-SQL query interfaces like BPF (Berkeley Packet Filter) or WinDivert filter strings. Unvalidated input can cause the system to drop all packets (DoS) or bypass intended IPS rules.
 **Prevention:** Always parse and explicitly validate network-related user input (e.g., verifying it successfully parses as `std::net::IpAddr` or `u16` ports) before incorporating it into packet filtering rules.
+## 2024-06-23 - Filter String Injection in WinDivert Engine
+**Vulnerability:** User-provided inputs (IP addresses and ports) were being directly concatenated into WinDivert filter strings in `ips_engine.rs` without validation.
+**Learning:** This is a classic injection vulnerability pattern applied to network filtering strings instead of SQL. Attackers could manipulate inputs (e.g., ports) with crafted payloads like `80 or ip.SrcAddr == 1.2.3.4` to bypass rules or drop all network traffic.
+**Prevention:** All user-provided network configuration values must be explicitly parsed into strict types (e.g., `std::net::IpAddr` for IPs and `u16` for ports) before string formatting, failing securely if parsing fails.

--- a/core/apps/guard-shield-tauri/src-tauri/src/ips_engine.rs
+++ b/core/apps/guard-shield-tauri/src-tauri/src/ips_engine.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, atomic::{AtomicBool, AtomicUsize, Ordering}};
+use std::net::IpAddr;
 use windivert::{WinDivert, prelude::WinDivertFlags};
 use crate::database::CustomRule;
 
@@ -39,7 +40,11 @@ impl IpsEngine {
         
         // 1. IP Auto-blocks
         for ip in blocked_ips {
-            filters.push(format!("(ip.SrcAddr == {} or ip.DstAddr == {})", ip, ip));
+            if let Ok(parsed_ip) = ip.parse::<IpAddr>() {
+                filters.push(format!("(ip.SrcAddr == '{}' or ip.DstAddr == '{}')", parsed_ip, parsed_ip));
+            } else {
+                eprintln!("Invalid blocked IP skipped: {}", ip);
+            }
         }
 
         // 2. Custom Drop Rules
@@ -52,45 +57,80 @@ impl IpsEngine {
             
             // Protocol matching
             if rule.protocol != "Any" {
-                rule_filters.push(rule.protocol.to_lowercase());
+                let proto = rule.protocol.to_lowercase();
+                if proto == "tcp" || proto == "udp" || proto == "icmp" {
+                    rule_filters.push(proto);
+                } else {
+                    eprintln!("Invalid protocol skipped: {}", rule.protocol);
+                    continue; // Skip the rule if protocol is invalid
+                }
             }
 
             // IP matching
+            let mut skip_rule = false;
             if let Some(src) = &rule.src_ip {
                 if !src.is_empty() {
-                    rule_filters.push(format!("ip.SrcAddr == {}", src));
+                    if let Ok(parsed_src) = src.parse::<IpAddr>() {
+                        rule_filters.push(format!("ip.SrcAddr == '{}'", parsed_src));
+                    } else {
+                        eprintln!("Invalid source IP skipped: {}", src);
+                        skip_rule = true;
+                    }
                 }
             }
             if let Some(dst) = &rule.dst_ip {
                 if !dst.is_empty() {
-                    rule_filters.push(format!("ip.DstAddr == {}", dst));
+                    if let Ok(parsed_dst) = dst.parse::<IpAddr>() {
+                        rule_filters.push(format!("ip.DstAddr == '{}'", parsed_dst));
+                    } else {
+                        eprintln!("Invalid destination IP skipped: {}", dst);
+                        skip_rule = true;
+                    }
                 }
+            }
+
+            if skip_rule {
+                continue;
             }
 
             // Port matching (requires tcp or udp in the rule filter)
             if let Some(src_port) = &rule.src_port {
                 if !src_port.is_empty() {
-                    if rule.protocol == "TCP" {
-                        rule_filters.push(format!("tcp.SrcPort == {}", src_port));
-                    } else if rule.protocol == "UDP" {
-                        rule_filters.push(format!("udp.SrcPort == {}", src_port));
-                    } else if rule.protocol == "Any" {
-                        // If protocol is Any, but port is specified, WinDivert needs us to specify it's a TCP or UDP packet.
-                        rule_filters.push(format!("((tcp and tcp.SrcPort == {}) or (udp and udp.SrcPort == {}))", src_port, src_port));
+                    if let Ok(parsed_port) = src_port.parse::<u16>() {
+                        if rule.protocol == "TCP" {
+                            rule_filters.push(format!("tcp.SrcPort == {}", parsed_port));
+                        } else if rule.protocol == "UDP" {
+                            rule_filters.push(format!("udp.SrcPort == {}", parsed_port));
+                        } else if rule.protocol == "Any" {
+                            // If protocol is Any, but port is specified, WinDivert needs us to specify it's a TCP or UDP packet.
+                            rule_filters.push(format!("((tcp and tcp.SrcPort == {}) or (udp and udp.SrcPort == {}))", parsed_port, parsed_port));
+                        }
+                    } else {
+                        eprintln!("Invalid source port skipped: {}", src_port);
+                        skip_rule = true;
                     }
                 }
             }
             
             if let Some(dst_port) = &rule.dst_port {
                 if !dst_port.is_empty() {
-                    if rule.protocol == "TCP" {
-                        rule_filters.push(format!("tcp.DstPort == {}", dst_port));
-                    } else if rule.protocol == "UDP" {
-                        rule_filters.push(format!("udp.DstPort == {}", dst_port));
-                    } else if rule.protocol == "Any" {
-                        rule_filters.push(format!("((tcp and tcp.DstPort == {}) or (udp and udp.DstPort == {}))", dst_port, dst_port));
+                    if let Ok(parsed_port) = dst_port.parse::<u16>() {
+                        if rule.protocol == "TCP" {
+                            rule_filters.push(format!("tcp.DstPort == {}", parsed_port));
+                        } else if rule.protocol == "UDP" {
+                            rule_filters.push(format!("udp.DstPort == {}", parsed_port));
+                        } else if rule.protocol == "Any" {
+                            rule_filters.push(format!("((tcp and tcp.DstPort == {}) or (udp and udp.DstPort == {}))", parsed_port, parsed_port));
+                        }
+                    } else {
+                        eprintln!("Invalid destination port skipped: {}", dst_port);
+                        skip_rule = true;
                     }
                 }
+            }
+
+            if skip_rule {
+                continue;
             }
 
             if !rule_filters.is_empty() {
@@ -110,10 +150,16 @@ impl IpsEngine {
         if !whitelisted_ips.is_empty() {
             let mut whitelist_filters = Vec::new();
             for w_ip in whitelisted_ips {
-                whitelist_filters.push(format!("(ip.SrcAddr == '{}' or ip.DstAddr == '{}')", w_ip, w_ip));
+                if let Ok(parsed_ip) = w_ip.parse::<IpAddr>() {
+                    whitelist_filters.push(format!("(ip.SrcAddr == '{}' or ip.DstAddr == '{}')", parsed_ip, parsed_ip));
+                } else {
+                    eprintln!("Invalid whitelist IP skipped: {}", w_ip);
+                }
             }
-            let whitelist_str = whitelist_filters.join(" or ");
-            filter_str = format!("({}) and !({})", filter_str, whitelist_str);
+            if !whitelist_filters.is_empty() {
+                let whitelist_str = whitelist_filters.join(" or ");
+                filter_str = format!("({}) and !({})", filter_str, whitelist_str);
+            }
         }
 
         std::thread::spawn(move || {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** User-provided inputs (IPs, Ports, Protocol) were directly concatenated into WinDivert filter strings without validation, leading to Filter String Injection.
🎯 **Impact:** Attackers could manipulate input fields to inject arbitrary filter strings, potentially allowing them to bypass custom IPS rules or create malicious rules to drop legitimate network traffic.
🔧 **Fix:** Implemented strict type parsing for all inputs (`std::net::IpAddr` for IPs, `u16` for ports) before formatting them into filter strings. Invalid properties or rules are explicitly skipped to fail securely.
✅ **Verification:** Ran `cargo check --target x86_64-pc-windows-gnu` and `pnpm lint` in the `core` directory. Added a learning log to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [12276626432121581904](https://jules.google.com/task/12276626432121581904) started by @lakshyarawat1*