### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unencrypted Threat Feed URL

### DIFF
--- a/core/apps/guard-shield-tauri/src-tauri/src/threat_feed.rs
+++ b/core/apps/guard-shield-tauri/src-tauri/src/threat_feed.rs
@@ -15,7 +15,8 @@ pub struct ThreatIndicator {
 }
 
 pub async fn fetch_cins_army() -> Result<Vec<ThreatIndicator>, String> {
-    let url = "http://cinsscore.com/list/ci-badguys.txt";
+    // 🛡️ Sentinel: Use HTTPS to prevent MITM attacks tampering with the threat feed.
+    let url = "https://cinsscore.com/list/ci-badguys.txt";
     let resp = reqwest::get(url).await.map_err(|e| e.to_string())?;
     let text = resp.text().await.map_err(|e| e.to_string())?;
     


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The CINS Army threat feed was being fetched over an unencrypted HTTP connection.
🎯 Impact: An attacker could perform a Machine-In-The-Middle (MITM) attack to intercept the request and inject false threat indicators, or prevent real ones from being downloaded, thus bypassing the IPS.
🔧 Fix: Upgraded the URL protocol to HTTPS.
✅ Verification: Ran `cargo check`, verified the codebase compiles without errors and the endpoint `https://cinsscore.com/list/ci-badguys.txt` is accessible.

---
*PR created automatically by Jules for task [8593508527285452591](https://jules.google.com/task/8593508527285452591) started by @lakshyarawat1*