### PR TITLE
⚡ Bolt: [performance improvement] Prevent TableVirtuoso inline component remounting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2025-02-28 - Avoid redundant string operations inside loops/filters
 **Learning:** In `ThreatFeed.tsx`, a `toLowerCase()` call was made repeatedly for the `searchTerm` variable inside the `.filter` loop callback. For arrays with hundreds or thousands of elements, this results in significant unnecessary work on the main thread.
 **Action:** Always pre-compute static values (like calling `toLowerCase()` on a search term) before entering a `.filter` or `.map` loop to ensure they are only calculated once.
+## 2025-06-24 - Inline Component Definitions inside Virtualized Lists cause Constant Remounting
+**Learning:** In `LiveTraffic.tsx`, defining sub-components (Table, TableRow, TableBody, EmptyPlaceholder) inline within the `components` prop of `TableVirtuoso` causes React to see them as new component types on every render. Given the frequent updates from live packet capture, this leads to continuous unmounting and remounting of the entire DOM subtree, drastically reducing performance and causing high CPU usage.
+**Action:** Always define components passed to virtualized lists (or any component accepting component props) at the module level outside the render loop. If they need state or props from the parent, pass it via the provided `context` prop.

--- a/core/apps/guard-shield-tauri/src/components/views/LiveTraffic.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/LiveTraffic.tsx
@@ -17,6 +17,48 @@ import { TableVirtuoso } from "react-virtuoso";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
 import { HexViewer } from "./HexViewer";
 
+// Virtualized table components defined outside render to prevent unmounting/remounting
+const VirtuosoTable = (props: any) => <table {...props} className="w-full caption-bottom text-sm" />;
+const VirtuosoTableHead = React.forwardRef((props, ref) => <thead {...props} ref={ref as any} className="bg-muted/40 sticky top-0 backdrop-blur-sm z-10 [&_tr]:border-b" />);
+const VirtuosoTableRow = (props: any) => <tr {...props} className="text-sm font-medium transition-colors hover:bg-muted/60 data-[state=selected]:bg-muted border-b" />;
+const VirtuosoTableBody = React.forwardRef((props, ref) => <tbody {...props} ref={ref as any} className="[&_tr:last-child]:border-0" />);
+const VirtuosoEmptyPlaceholder = ({ context }: any) => (
+  <tbody>
+    {context.error ? (
+      <tr>
+        <td colSpan={7} className="h-[24rem] text-center">
+          <div className="flex flex-col items-center justify-center text-destructive space-y-2">
+            <span className="text-4xl">⚠️</span>
+            <p className="font-bold text-lg">Packet Capture Failed</p>
+            <p className="text-sm max-w-md">{context.error}</p>
+            <p className="text-xs text-muted-foreground mt-4">Make sure to run the application as Administrator.</p>
+          </div>
+        </td>
+      </tr>
+    ) : context.packetsLength === 0 ? (
+      <tr>
+        <td colSpan={7} className="h-[24rem] text-center">
+          <div className="flex flex-col items-center justify-center text-muted-foreground space-y-2">
+            <span className="text-4xl animate-pulse">📡</span>
+            <p className="font-bold text-lg">Waiting for packets...</p>
+            <p className="text-sm">Listening on active network interface.</p>
+          </div>
+        </td>
+      </tr>
+    ) : context.filteredPacketsLength === 0 ? (
+      <tr>
+        <td colSpan={7} className="h-[24rem] text-center">
+          <div className="flex flex-col items-center justify-center text-muted-foreground space-y-2">
+            <span className="text-4xl">🔍</span>
+            <p className="font-bold text-lg">No matches found</p>
+            <p className="text-sm">Try adjusting your filters.</p>
+          </div>
+        </td>
+      </tr>
+    ) : null}
+  </tbody>
+);
+
 const getProtocolColor = (proto: string | undefined) => {
   if (!proto) return "bg-gray-500";
   const num = Number(proto);
@@ -229,47 +271,13 @@ export default function LiveTraffic() {
                 <TableVirtuoso
                   data={sortedPackets}
                   className="flex-1 w-full"
+                  context={{ error, packetsLength: packets.length, filteredPacketsLength: filteredPackets.length }}
                   components={{
-                    Table: (props) => <table {...props} className="w-full caption-bottom text-sm" />,
-                    TableHead: React.forwardRef((props, ref) => <thead {...props} ref={ref as any} className="bg-muted/40 sticky top-0 backdrop-blur-sm z-10 [&_tr]:border-b" />),
-                    TableRow: (props) => <tr {...props} className="text-sm font-medium transition-colors hover:bg-muted/60 data-[state=selected]:bg-muted border-b" />,
-                    TableBody: React.forwardRef((props, ref) => <tbody {...props} ref={ref as any} className="[&_tr:last-child]:border-0" />),
-                    EmptyPlaceholder: () => (
-                      <tbody>
-                        {error ? (
-                          <tr>
-                            <td colSpan={7} className="h-[24rem] text-center">
-                              <div className="flex flex-col items-center justify-center text-destructive space-y-2">
-                                <span className="text-4xl">⚠️</span>
-                                <p className="font-bold text-lg">Packet Capture Failed</p>
-                                <p className="text-sm max-w-md">{error}</p>
-                                <p className="text-xs text-muted-foreground mt-4">Make sure to run the application as Administrator.</p>
-                              </div>
-                            </td>
-                          </tr>
-                        ) : packets.length === 0 ? (
-                          <tr>
-                            <td colSpan={7} className="h-[24rem] text-center">
-                              <div className="flex flex-col items-center justify-center text-muted-foreground space-y-2">
-                                <span className="text-4xl animate-pulse">📡</span>
-                                <p className="font-bold text-lg">Waiting for packets...</p>
-                                <p className="text-sm">Listening on active network interface.</p>
-                              </div>
-                            </td>
-                          </tr>
-                        ) : filteredPackets.length === 0 ? (
-                          <tr>
-                            <td colSpan={7} className="h-[24rem] text-center">
-                              <div className="flex flex-col items-center justify-center text-muted-foreground space-y-2">
-                                <span className="text-4xl">🔍</span>
-                                <p className="font-bold text-lg">No matches found</p>
-                                <p className="text-sm">Try adjusting your filters.</p>
-                              </div>
-                            </td>
-                          </tr>
-                        ) : null}
-                      </tbody>
-                    )
+                    Table: VirtuosoTable,
+                    TableHead: VirtuosoTableHead,
+                    TableRow: VirtuosoTableRow,
+                    TableBody: VirtuosoTableBody,
+                    EmptyPlaceholder: VirtuosoEmptyPlaceholder,
                   }}
                   fixedHeaderContent={() => (
                     <tr>


### PR DESCRIPTION
**💡 What:** Moved inline component definitions (Table, TableRow, TableBody, EmptyPlaceholder) outside of the render function in `LiveTraffic.tsx` and used the `context` prop to pass external state into `EmptyPlaceholder`.
**🎯 Why:** Defining components inline within the `components` prop of `TableVirtuoso` causes React to see them as new component types on every render. With high-frequency live packet updates, this triggered continuous unmounting and remounting of the entire DOM subtree, causing a massive performance bottleneck.
**📊 Impact:** Expected to drastically reduce CPU usage and eliminate UI blocking on the Live Traffic screen, dropping DOM operations from O(N) to minimal updates.
**🔬 Measurement:** Start a live packet capture with TableVirtuoso active. Monitor the React Profiler to verify that table rows are re-rendering rather than unmounting/remounting, and CPU usage will be significantly lower.

---
*PR created automatically by Jules for task [15562306923956579400](https://jules.google.com/task/15562306923956579400) started by @lakshyarawat1*