### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-06-24 - Inline Component Definitions inside Virtualized Lists cause Constant Remounting
 **Learning:** In `LiveTraffic.tsx`, defining sub-components (Table, TableRow, TableBody, EmptyPlaceholder) inline within the `components` prop of `TableVirtuoso` causes React to see them as new component types on every render. Given the frequent updates from live packet capture, this leads to continuous unmounting and remounting of the entire DOM subtree, drastically reducing performance and causing high CPU usage.
 **Action:** Always define components passed to virtualized lists (or any component accepting component props) at the module level outside the render loop. If they need state or props from the parent, pass it via the provided `context` prop.
+
+## 2026-06-25 - Prevent O(N) filtering inside render loop
+**Learning:** Found an inline `.filter` array operation running on a large dataset (alerts) inside the React render cycle in `Monitoring.tsx`. This caused O(N) operations on every render, severely impacting performance for large amounts of alerts.
+**Action:** Use `useMemo` and derive metrics (like counts) from pre-existing memoized grouped data structures where possible to change O(N) operations into O(1) lookups.

--- a/core/apps/guard-shield-tauri/src/components/views/Monitoring.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/Monitoring.tsx
@@ -238,6 +238,12 @@ const Monitoring = () => {
     ].filter(d => d.value > 0);
   }, [alerts]);
 
+  // ⚡ Bolt Optimization: Memoize criticalCount calculation to prevent unnecessary O(n) array filter on every render.
+  const criticalCount = useMemo(() => {
+    const criticalData = severityCounts.find(s => s.name === "Critical");
+    return criticalData ? criticalData.value : 0;
+  }, [severityCounts]);
+
   return (
     <div className="flex flex-col gap-6 p-4 h-full w-full bg-background overflow-hidden">
       
@@ -275,7 +281,7 @@ const Monitoring = () => {
           </CardHeader>
           <CardContent>
             <div className="text-3xl font-bold text-destructive">
-              {alerts.filter(a => a.severity === "Critical").length.toLocaleString()}
+              {criticalCount.toLocaleString()}
             </div>
             <p className="text-xs text-muted-foreground mt-1">Require immediate attention</p>
           </CardContent>


### PR DESCRIPTION
💡 What: Extracted inline `alerts.filter()` into a memoized `criticalCount` derivation.
🎯 Why: `alerts` can be a large array (up to thousands of alerts), and the previous code executed an O(N) filter pass synchronously on every render of the `Monitoring` component, dropping frames. The new code leverages the pre-existing memoized `severityCounts` (O(1) lookup).
📊 Impact: Reduces main thread CPU time by completely eliminating a linear array scan on every render.
🔬 Measurement: Verified via `pnpm build` and `pnpm lint`. No regressions observed.

---
*PR created automatically by Jules for task [581168101666498820](https://jules.google.com/task/581168101666498820) started by @lakshyarawat1*