### PR TITLE
⚡ Bolt: [performance improvement] Memoize active rules calculation in Header.tsx

### DIFF
--- a/core/apps/guard-shield-tauri/src/components/views/Header.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/Header.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../components/ui/dropdown-menu";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
@@ -86,6 +86,11 @@ export function Header() {
     const interval = setInterval(fetchDroppedPackets, 1000);
     return () => clearInterval(interval);
   }, []);
+
+  // ⚡ Bolt Optimization: Memoize the count of active rules to prevent O(N) array filtering on every render cycle
+  const activeRulesCount = useMemo(() => {
+    return customRules.filter(r => r.is_active).length;
+  }, [customRules]);
 
   useEffect(() => {
     // Fetch rules periodically or on mount
@@ -260,8 +265,8 @@ export function Header() {
                 className="flex items-center gap-2 px-4 cursor-pointer"
                 variant="outline"
               >
-                {customRules.filter(r => r.is_active).length > 0 
-                  ? `${customRules.filter(r => r.is_active).length} Rules Active` 
+                {activeRulesCount > 0
+                  ? `${activeRulesCount} Rules Active`
                   : "No Rules Active"} <ChevronDown className="size-4" />{" "}
               </Button>
             </DropdownMenuTrigger>


### PR DESCRIPTION
### 💡 What:
Extracted the calculation of `activeRulesCount` in `Header.tsx` into a `useMemo` block.

### 🎯 Why:
Previously, the `customRules.filter(r => r.is_active)` code was evaluated multiple times inside the render method. Given that `customRules` is periodically polled every 2 seconds, this caused redundant `O(N)` filtering operations on every render cycle which could lead to small latency spikes as the number of rules increases.

### 📊 Impact:
* **Reduction of Re-Renders Overhead:** Eliminates redundant array filtering within the render tree, optimizing CPU cycle usage locally to the Header.

### 🔬 Measurement:
1. Ensure the Guard Shield backend builds.
2. Monitor that "Rules Active" counter renders correctly in the top bar.
3. Observe no performance regression when the app polls custom rules.

---
*PR created automatically by Jules for task [10883679540936782099](https://jules.google.com/task/10883679540936782099) started by @lakshyarawat1*