### PR TITLE
⚡ Bolt: Throttle Live Traffic packet updates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-06-25 - Prevent O(N) filtering inside render loop
 **Learning:** Found an inline `.filter` array operation running on a large dataset (alerts) inside the React render cycle in `Monitoring.tsx`. This caused O(N) operations on every render, severely impacting performance for large amounts of alerts.
 **Action:** Use `useMemo` and derive metrics (like counts) from pre-existing memoized grouped data structures where possible to change O(N) operations into O(1) lookups.
+
+## 2025-02-28 - Unthrottled State Updates with Large Datasets
+**Learning:** Found a critical performance bottleneck in `LiveTraffic.tsx` where high-frequency events (up to 10 emits/sec from Tauri backend) updated the component state immediately. Because the state contained a large array (up to 10,000 items) that was subsequently filtered and sorted (O(N log N)), updating the state 10 times a second crippled the main thread and caused high CPU usage.
+**Action:** Always buffer and throttle React state updates for high-frequency events (like websockets or IPC listeners) when dealing with large datasets or heavy derived state calculations. A throttle of 500ms (2fps) keeps the UI feeling real-time while drastically reducing main thread blocking.

--- a/core/apps/guard-shield-tauri/src/components/views/LiveTraffic.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/LiveTraffic.tsx
@@ -116,16 +116,28 @@ export default function LiveTraffic() {
 
   useEffect(() => {
     let unlisten: () => void;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let packetBuffer: PacketType[] = [];
 
     const setupCapture = async () => {
       try {
         setError(null);
         unlisten = await listen<PacketType[]>("packets-batch", (event) => {
-          setPackets((prev) => {
-            // Keep last 10000 packets for performance
-            const newPackets = [...event.payload.reverse(), ...prev];
-            return newPackets.slice(0, 10000);
-          });
+          packetBuffer = [...event.payload.reverse(), ...packetBuffer];
+
+          if (!timeoutId) {
+            timeoutId = setTimeout(() => {
+              const pendingPackets = [...packetBuffer];
+              packetBuffer = [];
+
+              setPackets((prev) => {
+                // Keep last 10000 packets for performance
+                const newPackets = [...pendingPackets, ...prev];
+                return newPackets.slice(0, 10000);
+              });
+              timeoutId = null;
+            }, 500); // ⚡ Bolt: Throttle React state updates to 2fps for better performance with large packet arrays
+          }
         });
       } catch (e) {
         console.error("Failed to setup packet capture:", e);
@@ -137,6 +149,7 @@ export default function LiveTraffic() {
 
     return () => {
       if (unlisten) unlisten();
+      if (timeoutId) clearTimeout(timeoutId);
     };
   }, []);
 


### PR DESCRIPTION
### 💡 What
Implemented a 500ms state update throttle for the `packets-batch` event listener in `LiveTraffic.tsx`. Incoming packets are buffered in a local array and flushed to the component's state at most twice a second.

### 🎯 Why
The Tauri backend can emit packet batches frequently (up to 10 times a second). Previously, `LiveTraffic.tsx` updated its state for every event. Since the state tracks up to 10,000 packets and the component performs heavy filtering and sorting operations on this array for every state change, this caused severe CPU overhead, blocking the main thread and resulting in a sluggish UI.

### 📊 Impact
Reduces React state updates, re-renders, and heavy O(N log N) array filtering and sorting operations by up to 80% during periods of high network activity, significantly reducing main thread blocking while keeping the UI feeling real-time (2fps).

### 🔬 Measurement
Run the application and navigate to the Live Traffic view. During high network activity (e.g., downloading a large file or streaming video), observe that the CPU usage of the frontend process is notably lower and the UI remains responsive, compared to before when the application would lag or stutter.

*Note: Added critical learning to `.jules/bolt.md`.*

---
*PR created automatically by Jules for task [9623687676959258033](https://jules.google.com/task/9623687676959258033) started by @lakshyarawat1*