### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information leakage in error messages

### DIFF
--- a/core/apps/guard-shield-tauri/src/components/views/GeneralSettings.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/GeneralSettings.tsx
@@ -6,6 +6,7 @@ import { Separator } from "../ui/separator";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "../ui/tabs";
 import { useTheme } from "../ThemeProvider";
 import { Paintbrush } from "lucide-react";
+import { toast } from "sonner";
 import { Switch } from "../ui/switch";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 
@@ -41,10 +42,10 @@ export default function GeneralSettings() {
   const handleSave = async () => {
     try {
       await invoke("save_settings", { settings });
-      alert("Settings saved successfully.");
+      toast.success("Settings saved successfully.");
     } catch (e) {
       console.error("Failed to save settings", e);
-      alert("Error: " + e);
+      toast.error("Failed to save settings.");
     }
   };
 
@@ -62,10 +63,10 @@ export default function GeneralSettings() {
     try {
       setIsClearing(true);
       await invoke("clear_database");
-      alert("Local logs successfully cleared.");
+      toast.success("Local logs successfully cleared.");
     } catch (e) {
       console.error("Failed to clear local logs", e);
-      alert("Error: " + e);
+      toast.error("Failed to clear local logs.");
     } finally {
       setIsClearing(false);
     }

--- a/core/apps/guard-shield-tauri/src/components/views/NetworkingSettings.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/NetworkingSettings.tsx
@@ -5,6 +5,7 @@ import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { Separator } from "../ui/separator";
+import { toast } from "sonner";
 
 export default function NetworkingSettings() {
   const [settings, setSettings] = useState<Record<string, string>>({
@@ -26,10 +27,10 @@ export default function NetworkingSettings() {
   const handleSave = async () => {
     try {
       await invoke("save_settings", { settings });
-      alert("Networking settings saved successfully.");
+      toast.success("Networking settings saved successfully.");
     } catch (e) {
       console.error("Failed to save settings", e);
-      alert("Error: " + e);
+      toast.error("Failed to save networking settings.");
     }
   };
 

--- a/core/apps/guard-shield-tauri/src/components/views/SystemHealth.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/SystemHealth.tsx
@@ -6,6 +6,7 @@ import Infobar from "./Infobar";
 import Sidebar from "./Sidebar";
 import ReactECharts from "echarts-for-react";
 import { useTheme } from "../ThemeProvider";
+import { toast } from "sonner";
 import { 
   Cpu, 
   Database, 
@@ -77,7 +78,7 @@ export default function SystemHealth() {
       })));
     } catch (e) {
       console.error("Failed to clear database", e);
-      alert("Error: " + e);
+      toast.error("Failed to clear database.");
     } finally {
       setIsClearing(false);
     }


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix information leakage in frontend error messages

🚨 Severity: MEDIUM
💡 Vulnerability: Information Exposure. The application was exposing raw internal error objects (which could contain file paths, stack traces, or backend Rust database error details) directly to the user interface via `alert()` pop-ups in several settings views.
🎯 Impact: Attackers could potentially gather reconnaissance data about the backend database paths or application logic when errors occur. Violates the "fail securely" principle.
🔧 Fix: Replaced `alert("Error: " + e)` calls with generic `toast.error("Failed to...")` messages in `SystemHealth.tsx`, `GeneralSettings.tsx`, and `NetworkingSettings.tsx`. Detailed errors remain securely logged to `console.error` for developer debugging.
✅ Verification: Ran `pnpm lint` and `pnpm build`. Tested visually mentally by reviewing the source code replacements.

This patch makes the application more robust and significantly improves UI/UX by removing blocking dialogs.

---
*PR created automatically by Jules for task [4983729622542434921](https://jules.google.com/task/4983729622542434921) started by @lakshyarawat1*