### PR TITLE
⚡ Bolt: Throttle React state updates for live alerts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,6 @@
 ## 2026-06-30 - Missing Debounce on Rapid Input Triggers Expensive Array Operations
 **Learning:** In `LiveTraffic.tsx`, state updates from typing in text fields directly triggered a `useMemo` filtering large arrays (up to 10,000 items). While the list rendering was virtualized, the upstream data operations still blocked the main thread on every keystroke, leading to severe input lag.
 **Action:** When filtering large collections based on text input, always decouple the raw input state from the filter logic dependency by introducing a debounced state to ensure O(N) operations only run once typing pauses.
+## 2025-02-28 - Unbatched State Updates from High-Frequency Events Block Main Thread
+**Learning:** Found a performance bottleneck in `AnalyticsDashboard.tsx` where an "intrusion-alert" Tauri listener triggered a React `setState` with a full array slice (`[event.payload, ...prev].slice(0, 1000)`) on every single event. During an alert storm, this causes hundreds of individual React re-renders per second, locking the main thread.
+**Action:** When handling high-frequency asynchronous events that update list state, always buffer incoming payloads into a mutable `useRef` array and flush them to state periodically inside a `setInterval`.

--- a/core/apps/guard-shield-tauri/src/components/views/AnalyticsDashboard.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/AnalyticsDashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { Header } from "./Header";
@@ -45,6 +45,7 @@ export default function AnalyticsDashboard() {
   const isFilled = localStorage.getItem("guard_shield_chart_filled") !== "false";
   const [alerts, setAlerts] = useState<AlertData[]>([]);
   const [stats, setStats] = useState<TelemetryStats>({ total_alerts: 0, last_24h_alerts: 0 });
+  const newAlertsBuffer = useRef<AlertData[]>([]);
   const [timeRangeStr, setTimeRangeStr] = useState<string>("5m");
   const timeRangeMs = useMemo(() => {
     if (timeRangeStr === "1m") return 60 * 1000;
@@ -85,11 +86,8 @@ export default function AnalyticsDashboard() {
     const setupListener = async () => {
       unlistenFn = await listen<AlertData>("intrusion-alert", (event) => {
         alertCountInSec += 1;
-        setAlerts((prev) => [event.payload, ...prev].slice(0, 1000));
-        setStats((prev) => ({
-          total_alerts: prev.total_alerts + 1,
-          last_24h_alerts: prev.last_24h_alerts + 1
-        }));
+        // ⚡ Bolt Optimization: Buffer incoming alerts to avoid triggering O(n) array derivations on every event
+        newAlertsBuffer.current.push(event.payload);
       });
       unlistenPackets = await listen<any[]>("packets-batch", (event) => {
         packetCountInSec += event.payload.length;
@@ -109,6 +107,20 @@ export default function AnalyticsDashboard() {
         }
         return next;
       });
+
+      // Flush buffered alerts to state periodically
+      if (newAlertsBuffer.current.length > 0) {
+        const newAlerts = newAlertsBuffer.current.slice();
+        newAlertsBuffer.current = []; // Clear buffer immediately
+        setAlerts(prev => {
+          const combined = [...newAlerts.reverse(), ...prev];
+          return combined.slice(0, 1000);
+        });
+        setStats(prev => ({
+          total_alerts: prev.total_alerts + newAlerts.length,
+          last_24h_alerts: prev.last_24h_alerts + newAlerts.length
+        }));
+      }
     }, 1000);
 
     return () => {


### PR DESCRIPTION
### 💡 What
Introduced a `useRef` buffer and interval-based batching for `setAlerts` and `setStats` in the `"intrusion-alert"` listener inside `AnalyticsDashboard.tsx`. Incoming payloads are now pushed to an array and flushed to state every 1000ms.

### 🎯 Why
Rapid individual state updates on every websocket/tauri event caused continuous re-evaluation of expensive array derivations (`scatterSeriesData`, `severityData`) and React re-renders. During an alert storm, this locks the main thread and causes severe UI lag.

### 📊 Impact
Changes the update frequency from potentially hundreds of times per second (O(N) operations per event) to a fixed interval (e.g., 1000ms). This drastically reduces CPU usage and maintains UI responsiveness during traffic spikes.

### 🔬 Measurement
Verify `AnalyticsDashboard` renders correctly and new alerts still appear in batches. Profile the application during an alert storm; React render cycle time and frequency should be significantly reduced.

---
*PR created automatically by Jules for task [16908161102659680903](https://jules.google.com/task/16908161102659680903) started by @lakshyarawat1*