### PR TITLE
⚡ Bolt: [performance improvement] Batch packet capture events to reduce re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,6 @@
 ## 2026-06-30 - Missing Debounce on Rapid Input Triggers Expensive Array Operations
 **Learning:** In `LiveTraffic.tsx`, state updates from typing in text fields directly triggered a `useMemo` filtering large arrays (up to 10,000 items). While the list rendering was virtualized, the upstream data operations still blocked the main thread on every keystroke, leading to severe input lag.
 **Action:** When filtering large collections based on text input, always decouple the raw input state from the filter logic dependency by introducing a debounced state to ensure O(N) operations only run once typing pauses.
+## 2025-02-28 - Unnecessary React re-renders on rapid async events
+**Learning:** High-frequency events (like `listen` payloads from Tauri) connected directly to React `useState` updater functions cause significant CPU overhead and UI blocking as React tries to re-render synchronously for every event.
+**Action:** Always decouple rapid external events from React state by buffering updates into a mutable `useRef` array and flushing to state on a `setInterval`.

--- a/core/apps/guard-shield-tauri/src/components/views/LiveTraffic.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/LiveTraffic.tsx
@@ -9,7 +9,7 @@ import Infobar from "./Infobar";
 import Sidebar from "./Sidebar";
 import { protocolNames } from "../../constants/constants";
 import { PacketType } from "../../types/dataTypes";
-import React, { useEffect, useState, useMemo } from "react";
+import React, { useEffect, useState, useMemo, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
 import { listen } from "@tauri-apps/api/event";
@@ -128,6 +128,10 @@ export default function LiveTraffic() {
     fetchInterfacesAndHistory();
   }, []);
 
+  // ⚡ Bolt: Use a mutable ref buffer to batch incoming packets and flush to React state via setInterval
+  // This prevents the main thread from being blocked by synchronous React state updates for every packet batch.
+  const packetBufferRef = useRef<PacketType[]>([]);
+
   useEffect(() => {
     let unlisten: () => void;
 
@@ -135,11 +139,8 @@ export default function LiveTraffic() {
       try {
         setError(null);
         unlisten = await listen<PacketType[]>("packets-batch", (event) => {
-          setPackets((prev) => {
-            // Keep last 10000 packets for performance
-            const newPackets = [...event.payload.reverse(), ...prev];
-            return newPackets.slice(0, 10000);
-          });
+          // Push to buffer instead of calling setPackets directly
+          packetBufferRef.current.push(...event.payload);
         });
       } catch (e) {
         console.error("Failed to setup packet capture:", e);
@@ -149,8 +150,24 @@ export default function LiveTraffic() {
 
     setupCapture();
 
+    const flushInterval = setInterval(() => {
+      if (packetBufferRef.current.length > 0) {
+        // Copy and reverse buffer to avoid mutating array inside state updater (Strict Mode safe)
+        const bufferedPackets = [...packetBufferRef.current].reverse();
+        // Clear buffer
+        packetBufferRef.current = [];
+
+        setPackets((prev) => {
+          // Keep last 10000 packets for performance
+          const newPackets = [...bufferedPackets, ...prev];
+          return newPackets.slice(0, 10000);
+        });
+      }
+    }, 500);
+
     return () => {
       if (unlisten) unlisten();
+      clearInterval(flushInterval);
     };
   }, []);
 


### PR DESCRIPTION
💡 **What**: Implemented a buffering mechanism in `LiveTraffic.tsx` using `useRef` and `setInterval` to batch incoming `packets-batch` events before flushing them to React state, replacing the previous logic which updated state on every single event trigger.

🎯 **Why**: The application was attempting to process and prepend packet data directly to a large array (up to 10,000 items) and triggering a React re-render cycle on every single IPC event. This led to high CPU overhead, constant unmounting/remounting of virtualized lists, and significant main thread blocking, making the app feel unresponsive during high traffic volumes.

📊 **Impact**: Massively reduces the number of synchronous render cycles and array `slice`/`reverse` operations. Instead of running potentially hundreds of times per second, the state update is now capped at running a maximum of twice per second (500ms intervals). This yields significantly lower CPU usage and eliminates input lag in the rest of the application.

🔬 **Measurement**: Measure the CPU usage of the app during a heavy packet capture load, and observe the main thread blocking time in Chrome DevTools Performance tab. You will see far fewer React commit phases and a much smoother UI.

---
*PR created automatically by Jules for task [7397186368521190798](https://jules.google.com/task/7397186368521190798) started by @lakshyarawat1*