### PR TITLE
⚡ Bolt: [performance improvement] Buffer high-frequency packet events

### DIFF
--- a/core/apps/guard-shield-tauri/src/components/views/LiveTraffic.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/LiveTraffic.tsx
@@ -9,7 +9,7 @@ import Infobar from "./Infobar";
 import Sidebar from "./Sidebar";
 import { protocolNames } from "../../constants/constants";
 import { PacketType } from "../../types/dataTypes";
-import React, { useEffect, useState, useMemo } from "react";
+import React, { useEffect, useState, useMemo, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
 import { listen } from "@tauri-apps/api/event";
@@ -128,6 +128,8 @@ export default function LiveTraffic() {
     fetchInterfacesAndHistory();
   }, []);
 
+  const packetBufferRef = useRef<PacketType[]>([]);
+
   useEffect(() => {
     let unlisten: () => void;
 
@@ -135,11 +137,8 @@ export default function LiveTraffic() {
       try {
         setError(null);
         unlisten = await listen<PacketType[]>("packets-batch", (event) => {
-          setPackets((prev) => {
-            // Keep last 10000 packets for performance
-            const newPackets = [...event.payload.reverse(), ...prev];
-            return newPackets.slice(0, 10000);
-          });
+          // Push to buffer instead of setting state directly to prevent excessive re-renders
+          packetBufferRef.current.push(...event.payload);
         });
       } catch (e) {
         console.error("Failed to setup packet capture:", e);
@@ -149,7 +148,27 @@ export default function LiveTraffic() {
 
     setupCapture();
 
+    // ⚡ Bolt: Buffer high-frequency async events and flush them periodically to avoid
+    // blocking the main thread and Strict Mode mutation bugs with arrays
+    const flushInterval = setInterval(() => {
+      if (packetBufferRef.current.length > 0) {
+        // Copy the buffer and clear it immediately
+        const bufferedPackets = packetBufferRef.current.slice();
+        packetBufferRef.current = [];
+
+        // Reverse outside the state updater to keep the updater pure
+        const reversedBatch = bufferedPackets.reverse();
+
+        setPackets((prev) => {
+          // Keep last 10000 packets for performance
+          const newPackets = [...reversedBatch, ...prev];
+          return newPackets.slice(0, 10000);
+        });
+      }
+    }, 1000);
+
     return () => {
+      clearInterval(flushInterval);
       if (unlisten) unlisten();
     };
   }, []);


### PR DESCRIPTION
💡 What: Refactored the `LiveTraffic` packet capture listener to buffer high-frequency events using `useRef` and a 1-second `setInterval` flush. Also fixed an array mutation bug where `.reverse()` was being called directly inside a React state updater.

🎯 Why: High-frequency packet streams continuously triggered React state updates natively, blocking the main thread, wasting CPU cycles on rapid component unmounting/remounting, and significantly lagging the UI (debounced inputs would freeze up). Additionally, the old `setPackets` call mutated array payloads within a React state updater, leading to bugs in React Strict Mode.

📊 Impact: Drastically reduces main-thread blocking operations. The DOM tree now only re-renders once per second, lowering CPU overhead substantially while still presenting real-time information smoothly.

🔬 Measurement: Profile CPU performance in a high-traffic environment before and after this change; the time spent scripting and rendering per frame will visibly decrease. Use Chrome DevTools Performance Profiler or monitor overall application responsiveness under heavy packet load.

---
*PR created automatically by Jules for task [16711170394966399764](https://jules.google.com/task/16711170394966399764) started by @lakshyarawat1*