### PR TITLE
⚡ Bolt: Throttle React state updates to improve dashboard performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -27,3 +27,6 @@
 ## 2026-06-30 - Missing Debounce on Rapid Input Triggers Expensive Array Operations
 **Learning:** In `LiveTraffic.tsx`, state updates from typing in text fields directly triggered a `useMemo` filtering large arrays (up to 10,000 items). While the list rendering was virtualized, the upstream data operations still blocked the main thread on every keystroke, leading to severe input lag.
 **Action:** When filtering large collections based on text input, always decouple the raw input state from the filter logic dependency by introducing a debounced state to ensure O(N) operations only run once typing pauses.
+## 2026-07-15 - Unthrottled State Updates in Dashboards
+**Learning:** Found a performance bottleneck in real-time dashboards (`AnalyticsDashboard`, `Monitoring`, `SuspiciousTraffic`) where high-frequency events (`intrusion-alert`) triggered immediate state updates, causing excessive re-renders and CPU spikes.
+**Action:** Always buffer and throttle React state updates for high-frequency streams using a `setTimeout` buffer. Batch updates and correctly maintain the reverse chronological order before flushing to the state.

--- a/core/apps/guard-shield-tauri/src-tauri/src/lib.rs
+++ b/core/apps/guard-shield-tauri/src-tauri/src/lib.rs
@@ -9,14 +9,7 @@ use std::sync::{Arc, Mutex, RwLock, atomic::{AtomicBool, Ordering}};
 use tauri::{AppHandle, Emitter, State, Manager};
 use tauri_plugin_fs::FsExt;
 use ips_engine::IpsEngine;
-use packet_capturer::PacketData;
 use std::collections::HashSet;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc, Mutex, RwLock,
-};
-use tauri::{AppHandle, Emitter, Manager, State};
-use tauri_plugin_fs::FsExt;
 
 struct AppState {
     capture_flag: Mutex<Option<Arc<AtomicBool>>>,

--- a/core/apps/guard-shield-tauri/src/components/views/AnalyticsDashboard.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/AnalyticsDashboard.tsx
@@ -82,14 +82,27 @@ export default function AnalyticsDashboard() {
     let alertCountInSec = 0;
     let packetCountInSec = 0;
 
+    let alertBuffer: AlertData[] = [];
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
     const setupListener = async () => {
       unlistenFn = await listen<AlertData>("intrusion-alert", (event) => {
         alertCountInSec += 1;
-        setAlerts((prev) => [event.payload, ...prev].slice(0, 1000));
-        setStats((prev) => ({
-          total_alerts: prev.total_alerts + 1,
-          last_24h_alerts: prev.last_24h_alerts + 1
-        }));
+        alertBuffer.push(event.payload);
+
+        if (!timeoutId) {
+          timeoutId = setTimeout(() => {
+            const pendingAlerts = [...alertBuffer];
+            alertBuffer = [];
+
+            setAlerts((prev) => [...pendingAlerts.reverse(), ...prev].slice(0, 1000));
+            setStats((prev) => ({
+              total_alerts: prev.total_alerts + pendingAlerts.length,
+              last_24h_alerts: prev.last_24h_alerts + pendingAlerts.length
+            }));
+            timeoutId = null;
+          }, 500); // ⚡ Bolt: Throttle React state updates to 2fps for better performance during high-frequency alerts
+        }
       });
       unlistenPackets = await listen<any[]>("packets-batch", (event) => {
         packetCountInSec += event.payload.length;
@@ -114,6 +127,7 @@ export default function AnalyticsDashboard() {
     return () => {
       if (unlistenFn) unlistenFn();
       if (unlistenPackets) unlistenPackets();
+      if (timeoutId) clearTimeout(timeoutId);
       clearInterval(interval);
     };
   }, []);

--- a/core/apps/guard-shield-tauri/src/components/views/Monitoring.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/Monitoring.tsx
@@ -196,22 +196,36 @@ const Monitoring = () => {
     };
     fetchTelemetry();
 
+    let unlistenFn: (() => void) | undefined;
+    let alertBuffer: AlertData[] = [];
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
     const setupListener = async () => {
       const unlisten = await listen<AlertData>("intrusion-alert", (event) => {
-          setAlerts((prev) => [event.payload, ...prev].slice(0, 500));
-          setStats((prev) => ({
-              total_alerts: prev.total_alerts + 1,
-              last_24h_alerts: prev.last_24h_alerts + 1
-          }));
+          alertBuffer.push(event.payload);
+
+          if (!timeoutId) {
+            timeoutId = setTimeout(() => {
+              const pendingAlerts = [...alertBuffer];
+              alertBuffer = [];
+
+              setAlerts((prev) => [...pendingAlerts.reverse(), ...prev].slice(0, 500));
+              setStats((prev) => ({
+                  total_alerts: prev.total_alerts + pendingAlerts.length,
+                  last_24h_alerts: prev.last_24h_alerts + pendingAlerts.length
+              }));
+              timeoutId = null;
+            }, 500); // ⚡ Bolt: Throttle React state updates to 2fps for better performance during high-frequency alerts
+          }
       });
       return unlisten;
     };
     
-    let unlistenFn: (() => void) | undefined;
     setupListener().then(fn => unlistenFn = fn);
 
     return () => {
       if (unlistenFn) unlistenFn();
+      if (timeoutId) clearTimeout(timeoutId);
     };
   }, []);
 

--- a/core/apps/guard-shield-tauri/src/components/views/SuspiciousTraffic.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/SuspiciousTraffic.tsx
@@ -67,20 +67,34 @@ export default function SuspiciousTraffic() {
     };
     fetchAlerts();
 
+    let unlistenFn: (() => void) | undefined;
+    let alertBuffer: AlertData[] = [];
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
     const setupListener = async () => {
       const unlisten = await listen<AlertData>("intrusion-alert", (event) => {
         if (event.payload.severity === "Critical" || event.payload.severity === "High") {
-          setAlerts((prev) => [event.payload, ...prev].slice(0, 500));
+          alertBuffer.push(event.payload);
+
+          if (!timeoutId) {
+            timeoutId = setTimeout(() => {
+              const pendingAlerts = [...alertBuffer];
+              alertBuffer = [];
+
+              setAlerts((prev) => [...pendingAlerts.reverse(), ...prev].slice(0, 500));
+              timeoutId = null;
+            }, 500); // ⚡ Bolt: Throttle React state updates to 2fps for better performance during high-frequency alerts
+          }
         }
       });
       return unlisten;
     };
     
-    let unlistenFn: (() => void) | undefined;
     setupListener().then(fn => unlistenFn = fn);
 
     return () => {
       if (unlistenFn) unlistenFn();
+      if (timeoutId) clearTimeout(timeoutId);
     };
   }, []);
 


### PR DESCRIPTION
💡 **What:** Added a 500ms timeout buffer to throttle incoming `intrusion-alert` Tauri events in `AnalyticsDashboard.tsx`, `Monitoring.tsx`, and `SuspiciousTraffic.tsx`. This batches incoming payloads and updates React state at most twice a second.

🎯 **Why:** Previously, high-frequency events would trigger immediate state updates for every single event, resulting in synchronously running costly array manipulations (`.slice`, spread operations) and cascading React re-renders on large datasets. During threat floods, this would cause severe CPU spikes and block the main thread.

📊 **Impact:** Throttles UI updates to ~2 FPS during event bursts, significantly reducing CPU load and maintaining UI responsiveness while properly aggregating total metrics.

🔬 **Measurement:** Verify by simulating a high volume of `intrusion-alert` events (e.g. 50+ per second) and observing the CPU usage and rendering performance of the dashboard pages.

---
*PR created automatically by Jules for task [11109344753112278664](https://jules.google.com/task/11109344753112278664) started by @lakshyarawat1*