### PR TITLE
⚡ Bolt: [performance improvement] Throttle React state updates in Monitoring component

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -27,3 +27,6 @@
 ## 2026-06-30 - Missing Debounce on Rapid Input Triggers Expensive Array Operations
 **Learning:** In `LiveTraffic.tsx`, state updates from typing in text fields directly triggered a `useMemo` filtering large arrays (up to 10,000 items). While the list rendering was virtualized, the upstream data operations still blocked the main thread on every keystroke, leading to severe input lag.
 **Action:** When filtering large collections based on text input, always decouple the raw input state from the filter logic dependency by introducing a debounced state to ensure O(N) operations only run once typing pauses.
+## 2025-06-25 - Unthrottled State Updates on Monitoring Dashboard
+**Learning:** High-frequency backend events (like `intrusion-alert`) that directly update state triggering heavy O(N) filtering operations (`useMemo` arrays) cause the main React thread to lock up.
+**Action:** When a listener emits data rapidly and the resulting UI operation is heavy, buffer the events locally using a `useRef` array and dispatch updates via `setInterval` to batch them. This prevents main thread blockage.

--- a/core/apps/guard-shield-tauri/src-tauri/src/lib.rs
+++ b/core/apps/guard-shield-tauri/src-tauri/src/lib.rs
@@ -9,14 +9,7 @@ use std::sync::{Arc, Mutex, RwLock, atomic::{AtomicBool, Ordering}};
 use tauri::{AppHandle, Emitter, State, Manager};
 use tauri_plugin_fs::FsExt;
 use ips_engine::IpsEngine;
-use packet_capturer::PacketData;
 use std::collections::HashSet;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc, Mutex, RwLock,
-};
-use tauri::{AppHandle, Emitter, Manager, State};
-use tauri_plugin_fs::FsExt;
 
 struct AppState {
     capture_flag: Mutex<Option<Arc<AtomicBool>>>,

--- a/core/apps/guard-shield-tauri/src/components/views/Monitoring.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/Monitoring.tsx
@@ -23,7 +23,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
 import { Sheet, SheetContent, SheetTitle, SheetDescription } from "../../components/ui/sheet";
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs";
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { HexViewer } from "./HexViewer";
@@ -52,6 +52,7 @@ interface TelemetryStats {
 const Monitoring = () => {
   const [alerts, setAlerts] = useState<AlertData[]>([]);
   const [stats, setStats] = useState<TelemetryStats>({ total_alerts: 0, last_24h_alerts: 0 });
+  const alertsBufferRef = useRef<AlertData[]>([]);
   const [severityFilter, setSeverityFilter] = useState<string>("All");
   const [searchQuery, setSearchQuery] = useState<string>("");
 
@@ -198,11 +199,7 @@ const Monitoring = () => {
 
     const setupListener = async () => {
       const unlisten = await listen<AlertData>("intrusion-alert", (event) => {
-          setAlerts((prev) => [event.payload, ...prev].slice(0, 500));
-          setStats((prev) => ({
-              total_alerts: prev.total_alerts + 1,
-              last_24h_alerts: prev.last_24h_alerts + 1
-          }));
+        alertsBufferRef.current.push(event.payload);
       });
       return unlisten;
     };
@@ -210,8 +207,28 @@ const Monitoring = () => {
     let unlistenFn: (() => void) | undefined;
     setupListener().then(fn => unlistenFn = fn);
 
+    // ⚡ Bolt Optimization: Batch process high-frequency alert updates via interval
+    // This prevents main thread blocking on rapid sequential updates
+    const flushInterval = setInterval(() => {
+      if (alertsBufferRef.current.length > 0) {
+        const newAlerts = [...alertsBufferRef.current];
+        alertsBufferRef.current = [];
+
+        setAlerts((prev) => {
+          const merged = [...newAlerts.reverse(), ...prev];
+          return merged.slice(0, 500);
+        });
+
+        setStats((prev) => ({
+          total_alerts: prev.total_alerts + newAlerts.length,
+          last_24h_alerts: prev.last_24h_alerts + newAlerts.length
+        }));
+      }
+    }, 1000);
+
     return () => {
       if (unlistenFn) unlistenFn();
+      clearInterval(flushInterval);
     };
   }, []);
 


### PR DESCRIPTION
💡 **What**: Refactored the `intrusion-alert` listener in the `Monitoring.tsx` component to buffer incoming payloads into a `useRef` array, then flush the buffer to React state in a batched manner once per second via `setInterval`.

🎯 **Why**: The backend could emit a high volume of `intrusion-alert` events rapidly during an active attack or scan. Each event previously updated the React state synchronously. Since updating `alerts` triggers a `useMemo` operation that filters and sorts up to 500 records on every update, updating state multiple times per second caused the React main thread to lock up, resulting in severe UI lag. 

📊 **Impact**: Reduces component re-renders from O(Events/sec) to a strict limit of 1 render per second. This turns an unmanageable load of O(N log N) filtering/sorting arrays into a smooth UI experience while maintaining accurate event rendering.

🔬 **Measurement**: Launch the dashboard and simulate a large flow of intrusion alerts from the backend. The UI should remain responsive, and React DevTools will indicate a maximum of 1 component re-render every 1000ms.

---
*PR created automatically by Jules for task [11332020780934998185](https://jules.google.com/task/11332020780934998185) started by @lakshyarawat1*