### PR TITLE
⚡ Bolt: [performance improvement] Derive criticalCount from memoized data

### DIFF
--- a/core/apps/guard-shield-tauri/src/components/views/AnalyticsDashboard.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/AnalyticsDashboard.tsx
@@ -159,10 +159,12 @@ export default function AnalyticsDashboard() {
     return Object.entries(counts).map(([name, value]) => ({ name, value })).sort((a, b) => b.value - a.value).slice(0, 5);
   }, [alerts]);
 
-  // ⚡ Bolt Optimization: Memoize criticalCount calculation to prevent unnecessary O(n) array filter on every render.
+  // ⚡ Bolt Optimization: Derive criticalCount from the already memoized severityData array.
+  // This turns an O(N) filter operation over the large alerts array into an O(1) lookup on the small severityData array.
   const criticalCount = useMemo(() => {
-    return alerts.filter(a => a.severity === "Critical").length;
-  }, [alerts]);
+    const criticalData = severityData.find(s => s.name === "Critical");
+    return criticalData ? criticalData.value : 0;
+  }, [severityData]);
 
   return (
     <div className="min-h-screen flex flex-col bg-background">


### PR DESCRIPTION
💡 **What:** The `criticalCount` in the `AnalyticsDashboard` is now derived from the already memoized `severityData` array by finding the "Critical" count. Previously, it performed a new `filter()` operation over the entire `alerts` array to determine this count. The old comment was also updated to reflect the new implementation.

🎯 **Why:** Filtering the full `alerts` array (which could be quite large) is an O(N) operation. Since `severityData` already processes the `alerts` array and tallies the counts per severity in O(N), we can leverage this existing computation. Finding the critical count inside `severityData` (an array of max 4 items) is an O(1) operation, preventing unnecessary iterations during render loops when state updates occur.

📊 **Impact:** Reduces the computational overhead required to derive the `criticalCount` metric. Transforms a redundant O(N) operation into an O(1) array lookup.

🔬 **Measurement:** The `AnalyticsDashboard` component should feel slightly more responsive, as the UI thread does less redundant computation. Visual correctness can be tested by observing the "Critical Threats" hero metric which should still report the correct count.

---
*PR created automatically by Jules for task [12268325008591418203](https://jules.google.com/task/12268325008591418203) started by @lakshyarawat1*