### PR TITLE
⚡ Bolt: Buffer high-frequency intrusion alerts in AnalyticsDashboard

### DIFF
--- a/core/apps/guard-shield-tauri/src/components/views/AnalyticsDashboard.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/AnalyticsDashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { Header } from "./Header";
@@ -45,6 +45,9 @@ export default function AnalyticsDashboard() {
   const isFilled = localStorage.getItem("guard_shield_chart_filled") !== "false";
   const [alerts, setAlerts] = useState<AlertData[]>([]);
   const [stats, setStats] = useState<TelemetryStats>({ total_alerts: 0, last_24h_alerts: 0 });
+
+  // ⚡ Bolt: Buffer incoming events to prevent synchronous React state updates on every event
+  const alertBufferRef = useRef<AlertData[]>([]);
   const [timeRangeStr, setTimeRangeStr] = useState<string>("5m");
   const timeRangeMs = useMemo(() => {
     if (timeRangeStr === "1m") return 60 * 1000;
@@ -85,11 +88,7 @@ export default function AnalyticsDashboard() {
     const setupListener = async () => {
       unlistenFn = await listen<AlertData>("intrusion-alert", (event) => {
         alertCountInSec += 1;
-        setAlerts((prev) => [event.payload, ...prev].slice(0, 1000));
-        setStats((prev) => ({
-          total_alerts: prev.total_alerts + 1,
-          last_24h_alerts: prev.last_24h_alerts + 1
-        }));
+        alertBufferRef.current.push(event.payload);
       });
       unlistenPackets = await listen<any[]>("packets-batch", (event) => {
         packetCountInSec += event.payload.length;
@@ -99,6 +98,17 @@ export default function AnalyticsDashboard() {
 
     const interval = setInterval(() => {
       const now = Date.now();
+
+      // Flush buffered alerts to React state
+      if (alertBufferRef.current.length > 0) {
+        const newAlerts = alertBufferRef.current.splice(0, alertBufferRef.current.length).reverse();
+        setAlerts(prev => [...newAlerts, ...prev].slice(0, 1000));
+        setStats(prev => ({
+          total_alerts: prev.total_alerts + newAlerts.length,
+          last_24h_alerts: prev.last_24h_alerts + newAlerts.length
+        }));
+      }
+
       setTrafficHistory(prev => {
         const next = [...prev, { time: now, pkts: packetCountInSec, alerts: alertCountInSec }];
         packetCountInSec = 0;


### PR DESCRIPTION
💡 What: Buffered high-frequency incoming `intrusion-alert` IPC events in `AnalyticsDashboard.tsx` into a `useRef` array, periodically flushing them to the component's state using a batch update in the pre-existing `setInterval` loop.

🎯 Why: To prevent heavy and expensive ECharts components from synchronously re-rendering on every individual intrusion alert during network traffic spikes. Updating the component state on a per-event basis with unthrottled payloads drastically impacted framerates and locked up the main thread.

📊 Impact: Reduces synchronous re-renders from O(events) to O(1) per second, significantly smoothing out dashboard UI responsiveness during massive alert storms while maintaining accurate metrics and chronological ordering.

🔬 Measurement: Verify by triggering a burst of `intrusion-alert` events. Check the React Developer Tools profiler to confirm that `AnalyticsDashboard` only re-renders once per second, despite hundreds of incoming events.

---
*PR created automatically by Jules for task [7305680579047284909](https://jules.google.com/task/7305680579047284909) started by @lakshyarawat1*