### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,6 @@
 ## 2025-02-28 - Buffer high-frequency async events from Tauri
 **Learning:** In `LiveTraffic.tsx`, directly calling `setPackets` synchronously on every incoming batch from the `listen` Tauri event causes excessive React re-renders, especially under high network load.
 **Action:** Use a mutable `useRef` array to buffer incoming asynchronous events (like `listen` payloads) and flush the buffer to React state on a fixed `setInterval` (e.g. 1000ms).
+## 2025-02-28 - Unnecessary array spreading in high-frequency events
+**Learning:** Found an anti-pattern in `LiveTraffic.tsx` where an array was spread inside a high frequency event listener `packetBuffer = [...event.payload.reverse(), ...packetBuffer];` which causes high CPU load.
+**Action:** When handling high-frequency network events (like packet batching) in the React frontend, buffer incoming payloads into a mutable `useRef` array using `.push(...)` (avoiding O(N^2) array spreading).

--- a/core/apps/guard-shield-tauri/src/components/views/LiveTraffic.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/LiveTraffic.tsx
@@ -133,28 +133,16 @@ export default function LiveTraffic() {
     let unlisten: () => void;
     let intervalId: ReturnType<typeof setInterval>;
     let isMounted = true;
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-    let packetBuffer: PacketType[] = [];
 
     const setupCapture = async () => {
       try {
         setError(null);
         unlisten = await listen<PacketType[]>("packets-batch", (event) => {
-          packetBuffer = [...event.payload.reverse(), ...packetBuffer];
-
-          if (!timeoutId) {
-            timeoutId = setTimeout(() => {
-              const pendingPackets = [...packetBuffer];
-              packetBuffer = [];
-
-              setPackets((prev) => {
-                // Keep last 10000 packets for performance
-                const newPackets = [...pendingPackets, ...prev];
-                return newPackets.slice(0, 10000);
-              });
-              timeoutId = null;
-            }, 500); // ⚡ Bolt: Throttle React state updates to 2fps for better performance with large packet arrays
-          }
+          // ⚡ Bolt Optimization: Buffer incoming packets into a ref directly.
+          // Spreading arrays inside high-frequency listeners causes high CPU load,
+          // and triggering state changes multiple times a second is an anti-pattern
+          // when dealing with arrays of 10k items.
+          bufferRef.current.push(...event.payload);
         });
 
         intervalId = setInterval(() => {
@@ -185,7 +173,6 @@ export default function LiveTraffic() {
       isMounted = false;
       if (intervalId) clearInterval(intervalId);
       if (unlisten) unlisten();
-      if (timeoutId) clearTimeout(timeoutId);
     };
   }, []);
 


### PR DESCRIPTION
💡 What: Replaced array spreading inside high-frequency `packets-batch` listener with direct `.push()` into `bufferRef`. Removed redundant `setTimeout` that triggered unnecessary state updates alongside the existing `setInterval`.
🎯 Why: Spreading arrays inside high-frequency event listeners causes O(N^2) time complexity and high CPU usage. Also, having multiple mechanisms (`setTimeout` and `setInterval`) trying to flush buffers and update React state causes excessive synchronous re-renders.
📊 Impact: Significantly reduces CPU usage and main thread blocking during high network load by batching all incoming events into a mutable ref and flushing them on a fixed 1-second interval.
🔬 Measurement: Use the application under high network load and observe the CPU usage. The UI should remain responsive and not freeze.

---
*PR created automatically by Jules for task [10335761705181219324](https://jules.google.com/task/10335761705181219324) started by @lakshyarawat1*