### PR TITLE
⚡ Bolt: Optimize Live Traffic Event Listener Performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,6 @@
 ## 2025-02-28 - Buffer high-frequency async events from Tauri
 **Learning:** In `LiveTraffic.tsx`, directly calling `setPackets` synchronously on every incoming batch from the `listen` Tauri event causes excessive React re-renders, especially under high network load.
 **Action:** Use a mutable `useRef` array to buffer incoming asynchronous events (like `listen` payloads) and flush the buffer to React state on a fixed `setInterval` (e.g. 1000ms).
+## 2024-05-18 - Avoid O(N^2) Array Spread in React Event Listeners
+**Learning:** In high-frequency Tauri event listeners (like live network traffic), using array spread syntax (`[...new, ...old]`) directly inside the listener callback degrades to O(N^2) time complexity and causes UI freezing before debounced state updates trigger.
+**Action:** Always append high-frequency event payloads to a mutable `useRef` array using `.push(...)`, maintain strict bounds with `.slice`, and only perform array spread/copy operations periodically inside a flushing `setInterval` to batch state updates.

--- a/core/apps/guard-shield-tauri/src/components/views/LiveTraffic.tsx
+++ b/core/apps/guard-shield-tauri/src/components/views/LiveTraffic.tsx
@@ -133,43 +133,34 @@ export default function LiveTraffic() {
     let unlisten: () => void;
     let intervalId: ReturnType<typeof setInterval>;
     let isMounted = true;
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-    let packetBuffer: PacketType[] = [];
 
     const setupCapture = async () => {
       try {
         setError(null);
         unlisten = await listen<PacketType[]>("packets-batch", (event) => {
-          packetBuffer = [...event.payload.reverse(), ...packetBuffer];
-
-          if (!timeoutId) {
-            timeoutId = setTimeout(() => {
-              const pendingPackets = [...packetBuffer];
-              packetBuffer = [];
-
-              setPackets((prev) => {
-                // Keep last 10000 packets for performance
-                const newPackets = [...pendingPackets, ...prev];
-                return newPackets.slice(0, 10000);
-              });
-              timeoutId = null;
-            }, 500); // ⚡ Bolt: Throttle React state updates to 2fps for better performance with large packet arrays
+          // ⚡ Bolt Optimization: Avoid O(N^2) array spreading inside listener
+          // Push new packets directly to a mutable ref buffer and keep strict limit
+          bufferRef.current.push(...event.payload);
+          if (bufferRef.current.length > 10000) {
+            bufferRef.current = bufferRef.current.slice(-10000);
           }
         });
 
         intervalId = setInterval(() => {
           if (bufferRef.current.length > 0) {
-            // ⚡ Bolt Optimization: Buffer incoming packets from Tauri `listen` events
-            // and flush them periodically. This prevents excessive synchronous React re-renders
+            // ⚡ Bolt Optimization: Flush incoming packets from Tauri `listen` events periodically
+            // This batches updates and prevents excessive synchronous React re-renders
             // when handling high-frequency live network traffic.
-            const itemsToAdd = bufferRef.current.splice(0, bufferRef.current.length).reverse();
+            const itemsToAdd = [...bufferRef.current].reverse();
+            bufferRef.current = [];
+
             setPackets((prev) => {
               // Keep last 10000 packets for performance
               const newPackets = [...itemsToAdd, ...prev];
               return newPackets.slice(0, 10000);
             });
           }
-        }, 1000);
+        }, 500); // ⚡ Bolt: Throttle React state updates to 2fps for better performance
       } catch (e) {
         console.error("Failed to setup packet capture:", e);
         setError(String(e));
@@ -185,7 +176,6 @@ export default function LiveTraffic() {
       isMounted = false;
       if (intervalId) clearInterval(intervalId);
       if (unlisten) unlisten();
-      if (timeoutId) clearTimeout(timeoutId);
     };
   }, []);
 


### PR DESCRIPTION
💡 What: Replaced O(N^2) array spreading inside the Tauri `packets-batch` listener with `bufferRef.current.push(...)`. Cleaned up the update loops to use a single 500ms (2fps) flush timer.

🎯 Why: During high network traffic, appending large arrays via the spread operator on every single event degrades to O(N^2) time complexity. This causes the main thread to block and results in severe UI lag.

📊 Impact: Massively reduces CPU load and garbage collection thrashing during active network sniffing, keeping the UI responsive even during packet flooding.

🔬 Measurement: Observe the "Live Traffic" page while capturing active network downloads. The UI will no longer freeze or skip frames due to excessive synchronous array spread computations.

---
*PR created automatically by Jules for task [4799082944527616000](https://jules.google.com/task/4799082944527616000) started by @lakshyarawat1*